### PR TITLE
Geo Routing Images from SharePoint

### DIFF
--- a/libs/features/georoutingv2/georoutingv2.css
+++ b/libs/features/georoutingv2/georoutingv2.css
@@ -3,7 +3,7 @@
 }
 
 .dialog-modal.locale-modal-v2 {
-  background-image: url('/libs/features/georoutingv2/img/GeoModal_BG_Map_Mobile.png');
+  background-image: url('/libs/img/georouting/background-mobile.png?format=webply&optimize=medium');
   background-position: center;
   background-repeat: no-repeat;
   background-size: cover;
@@ -116,7 +116,7 @@
 
 @media (min-width: 480px) {
   .dialog-modal.locale-modal-v2 {
-    background-image: url('/libs/features/georoutingv2/img/GeoModal_BG_Map_Tablet.png');
+    background-image: url('/libs/img/georouting/background-tablet.png?format=webply&optimize=medium');
   }
 }
 
@@ -138,6 +138,6 @@
 
 @media (min-width: 1200px) {
   .dialog-modal.locale-modal-v2 {
-    background-image: url('/libs/features/georoutingv2/img/GeoModal_BG_Map_Desktop.png');
+    background-image: url('/libs/img/georouting/background-desktop.png?format=webply&optimize=medium');
   }
 }


### PR DESCRIPTION
### Geo Routing Images from SharePoint

Changes

- Relocation of Assets: Geo routing background images have been moved to the [/libs/img/georouting/ ](https://adobe.sharepoint.com/:f:/r/sites/adobecom/Shared%20Documents/milo/libs/img/[georouting](https://adobe.sharepoint.com/:f:/r/sites/adobecom/Shared%20Documents/milo/libs/img/georouting?csf=1&web=1&e=QS0r2j)?csf=1&web=1&e=QS0r2j)directory.
- Compressed Image Format: WebP


#### Test URLs

Homepage
Before: https://main--homepage--adobecom.hlx.live/homepage/index-loggedout?martech=off&&akamaiLocale=MX
After:  https://main--homepage--adobecom.hlx.live/homepage/index-loggedout?milolibs=mwpw-137903--milo--joaquinrivero&martech=off&akamaiLocale=MX

Acrobat
Before: https://main--dc--adobecom.hlx.page/?martech=off&&akamaiLocale=MX
After: https://main--dc--adobecom.hlx.page/?milolibs=mwpw-137903--milo--joaquinrivero&martech=off&akamaiLocale=MX

BACOM
Before: https://main--bacom--adobecom.hlx.page/?martech=off&&akamaiLocale=MX
After: https://main--bacom--adobecom.hlx.page/?milolibs=mwpw-137903--milo--joaquinrivero&martech=off&akamaiLocale=MX

CC
Before: https://main--cc--adobecom.hlx.page/?martech=off&&akamaiLocale=MX
After: https://main--cc--adobecom.hlx.page/?milolibs=mwpw-137903--milo--joaquinrivero&martech=off&akamaiLocale=MX

Milo:
https://mwpw-137903--milo--joaquinrivero.hlx.page